### PR TITLE
Fix double xterm window

### DIFF
--- a/package/debian-live/addons.d/10-gui.sh
+++ b/package/debian-live/addons.d/10-gui.sh
@@ -8,8 +8,6 @@ PACKAGES="$PACKAGES emacs"
 
     mkdir -p $TARGETROOT/etc/xdg/openbox
     cat <<EOF >$TARGETROOT/etc/xdg/openbox/autostart
-# Starting terminal
-xterm &
 
 # Open browser if index.html is provided
 if [ -f ~/htdocs/index.html ]; then


### PR DESCRIPTION
Double xterm window shows, as when gui starts xterm already is started. Not sure if this is a jessie issue as I found this with a jessie build, anyways removing the xterm call stops it. 