### PR TITLE
Fix/xterm

### DIFF
--- a/package/debian-live/.gitignore
+++ b/package/debian-live/.gitignore
@@ -1,0 +1,17 @@
+# Ignore build files!
+
+.build/
+binary/
+build.log
+cache/
+chroot.files
+chroot.packages.install
+chroot.packages.live
+chroot/
+config/
+live-image-amd64.contents
+live-image-amd64.files
+live-image-amd64.hybrid.iso
+live-image-amd64.hybrid.iso.zsync
+live-image-amd64.packages
+sysconf.txt

--- a/package/debian-live/addons.d/10-gui.sh
+++ b/package/debian-live/addons.d/10-gui.sh
@@ -4,32 +4,48 @@ PACKAGES="$PACKAGES mupdf xli"
 # I am an emacs guy
 PACKAGES="$PACKAGES emacs"
 
-# files to install
+# create system autostart for openbox
 
     mkdir -p $TARGETROOT/etc/xdg/openbox
     cat <<EOF >$TARGETROOT/etc/xdg/openbox/autostart
+
+# load background image if available in user home
+if [ -f ~/.xrootimage.png ] ; then
+    xli -onroot -fillscreen ~/.xrootimage.png
+fi
 
 # Open browser if index.html is provided
 if [ -f ~/htdocs/index.html ]; then
   chromium ~/htdocs/index.html &
 fi
 
-# load background image if available in user home
-if [ -f ~/.xrootimage.png ] ; then
-    xli -onroot -fillscreen ~/.xrootimage.png
-fi
+# Open terminal
+xterm &
+
 EOF
+
+
+# create user template for openbox
+
+    cat <<EOF >$TARGETROOT/etc/xdg/openbox/user-autostart-template
+
+# Users openbox autostart file
+# Add custom openbox autostart in this file
+
+EOF
+
 
 # prepare user's wm startup
-    cat <<EOF >$TARGETROOT/etc/rc.local.d/gui-setup
+
+    mkdir $TARGETROOT/etc/profile.d
+    cat <<EOF >$TARGETROOT/etc/profile.d/gui-setup.sh
 #!/bin/sh -e
 
-if [ ! -d /home/$USERNAME/.config/openbox ] ; then
-    mkdir -p /home/$USERNAME/.config/openbox
-    cp /etc/xdg/openbox/autostart /home/$USERNAME/.config/openbox/
-    chown -R $USERNAME /home/$USERNAME/.config
+if [ ! -d ~/.config/openbox ] ; then
+    mkdir -p ~/.config/openbox
+    cp /etc/xdg/openbox/user-autostart-template ~/.config/openbox/autostart
+    chown -R $LOGNAME ~/.config
 fi
 EOF
 
-chmod 755 $TARGETROOT/etc/rc.local.d/gui-setup
-
+chmod 755 $TARGETROOT/etc/profile.d/gui-setup.sh

--- a/package/debian-live/clean-build.sh
+++ b/package/debian-live/clean-build.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+# clear locks
+echo "Clearing locks on chroot, killing processes"
+fuser -f chroot
+ 
+# run clean
+echo "Running lb clean"
+lb clean
+
+
+# remove extra files
+echo "Remove config"
+rm -rf ./config
+rm -vi sysconf.txt
+rm -vi build.log
+
+echo "Clean complete"
+


### PR DESCRIPTION
Now this should fix the double window correctly. 

We keep the code int he system autostart, the change was we check for config in `/etc/profile.d/` script and add it. It's really a blank template. 

Also added a .gitignore file for the build files, and a clean up script to clean up the build directory. Was handy when testing. 
