### PR TITLE
updated script secret to not echo secret share

### DIFF
--- a/bin/secret
+++ b/bin/secret
@@ -64,6 +64,7 @@ use Getopt::Long;
 use Pod::Usage;
 use OpenXPKI::Crypto::Secret;
 use Data::Dumper;
+use Term::ReadKey;
 
 use English;
 
@@ -149,7 +150,9 @@ if ($cmd eq 'generate') {
 	    }
 	    print STDERR "Please enter share: ";
 	}
+	ReadMode('noecho');
 	my $line = <>;
+	ReadMode('normal');
 	chomp $line;
 	$line = uc($line);
 	eval {


### PR DESCRIPTION
For our use case the secret share cannot be shown while it's being entered, so I disabled terminal echo.